### PR TITLE
feat: best effort auto pool ENS registration

### DIFF
--- a/cmd/service/init.go
+++ b/cmd/service/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/grassrootseconomics/eth-custodial/internal/api"
+	ensclient "github.com/grassrootseconomics/eth-custodial/internal/ens_client"
 	"github.com/grassrootseconomics/eth-custodial/internal/gas"
 	internaljs "github.com/grassrootseconomics/eth-custodial/internal/jetstream"
 	"github.com/grassrootseconomics/eth-custodial/internal/pub"
@@ -29,6 +30,7 @@ var (
 	registry        map[string]common.Address
 	workerContainer *worker.WorkerContainer
 	apiServer       *api.API
+	ensClient       *ensclient.EnsClient
 
 	js       jetstream.JetStream
 	natsConn *nats.Conn
@@ -143,6 +145,19 @@ func loadPub() *pub.Pub {
 	return jsPub
 }
 
+func loadEnsClient() *ensclient.EnsClient {
+	if ensClient != nil {
+		return ensClient
+	}
+
+	ensClient = ensclient.New(
+		ko.MustString("ens.api_key"),
+		ko.MustString("ens.endpoint"),
+	)
+
+	return ensClient
+}
+
 func initSub() *sub.Sub {
 	if jsSub != nil {
 		return jsSub
@@ -179,6 +194,7 @@ func initWorker() *worker.WorkerContainer {
 		Logg:          lo,
 		Pub:           loadPub(),
 		ChainProvider: loadChainProvider(),
+		EnsClient:     loadEnsClient(),
 		Prod:          ko.Bool("workers.prod"),
 	}
 

--- a/config.toml
+++ b/config.toml
@@ -47,3 +47,7 @@ banned_tokens = ["0x471EcE3750Da237f93B8E339c536989b8978a438"]
 endpoint = "nats://127.0.0.1:4222"
 id = "eth-custodial-1"
 persist_duration_hrs = 48
+
+[ens]
+endpoint = "http://localhost:5015"
+api_key = ""

--- a/internal/ens_client/client.go
+++ b/internal/ens_client/client.go
@@ -1,0 +1,114 @@
+package ensclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	registerAPIPath = "/api/v1/internal/register"
+
+	SuffixENSName = ".sarafu.eth"
+)
+
+type (
+	EnsClient struct {
+		apiKey     string
+		endpoint   string
+		httpClient *http.Client
+	}
+
+	RegisterInput struct {
+		Address string `json:"address"`
+		Hint    string `json:"hint"`
+	}
+
+	RegisterResult struct {
+		Address    string `json:"address"`
+		AutoChoose bool   `json:"autoChoose"`
+		Name       string `json:"name"`
+	}
+
+	RegisterResponse struct {
+		Ok          bool           `json:"ok"`
+		Description string         `json:"description"`
+		Result      RegisterResult `json:"result"`
+	}
+)
+
+func New(apiKey string, endpoint string) *EnsClient {
+	return &EnsClient{
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
+		endpoint: endpoint,
+	}
+}
+
+func (ec *EnsClient) SetHTTPClient(httpClient *http.Client) *EnsClient {
+	ec.httpClient = httpClient
+	return ec
+}
+
+func (ec *EnsClient) setDefaultHeaders(req *http.Request) *http.Request {
+	req.Header.Set("Authorization", "Bearer "+ec.apiKey)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func (ec *EnsClient) postRequestWithCtx(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return ec.do(req)
+}
+
+func (ec *EnsClient) do(req *http.Request) (*http.Response, error) {
+	return ec.httpClient.Do(ec.setDefaultHeaders(req))
+}
+
+func parseResponse(resp *http.Response, target interface{}) error {
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return fmt.Errorf("ENS server error: code=%s: response_body=%s", resp.Status, string(b))
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func (ec *EnsClient) Register(ctx context.Context, input RegisterInput) (RegisterResponse, error) {
+	var (
+		buf              bytes.Buffer
+		registerResponse RegisterResponse
+	)
+
+	if err := json.NewEncoder(&buf).Encode(input); err != nil {
+		return registerResponse, err
+	}
+
+	resp, err := ec.postRequestWithCtx(ctx, ec.endpoint+registerAPIPath, &buf)
+	if err != nil {
+		return registerResponse, err
+	}
+
+	if err := parseResponse(resp, &registerResponse); err != nil {
+		return registerResponse, err
+	}
+
+	return registerResponse, nil
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	ensclient "github.com/grassrootseconomics/eth-custodial/internal/ens_client"
 	"github.com/grassrootseconomics/eth-custodial/internal/gas"
 	"github.com/grassrootseconomics/eth-custodial/internal/pub"
 	"github.com/grassrootseconomics/eth-custodial/internal/store"
@@ -26,6 +27,7 @@ type (
 		Logg                *slog.Logger
 		ChainProvider       *ethutils.Provider
 		Pub                 *pub.Pub
+		EnsClient           *ensclient.EnsClient
 		// TODO: temporary patch for prod because poolIndex doesn't exist in the entry point registry
 		Prod bool
 	}
@@ -43,6 +45,7 @@ type (
 		logg          *slog.Logger
 		pub           *pub.Pub
 		chainProvider *ethutils.Provider
+		ensClient     *ensclient.EnsClient
 		prod          bool
 	}
 )
@@ -61,6 +64,7 @@ func New(o WorkerOpts) (*WorkerContainer, error) {
 		logg:          o.Logg,
 		pub:           o.Pub,
 		chainProvider: o.ChainProvider,
+		ensClient:     o.EnsClient,
 		prod:          o.Prod,
 	}
 


### PR DESCRIPTION
Clients can then reverse query the pool ENS to find out the name and display it. Alternatively, try ${symbolname}.sarafu.eth.

closes #70 