### PR TITLE
fix: address unlocker worker review feedback

### DIFF
--- a/internal/worker/unlocker.go
+++ b/internal/worker/unlocker.go
@@ -1,0 +1,349 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/grassrootseconomics/eth-custodial/internal/store"
+	"github.com/lmittmann/w3"
+	"github.com/lmittmann/w3/module/eth"
+	"github.com/riverqueue/river"
+)
+
+type (
+	UnlockerArgs struct{}
+
+	UnlockerWorker struct {
+		river.WorkerDefaults[UnlockerArgs]
+		wc *WorkerContainer
+	}
+)
+
+const UnlockerID = "UNLOCKER"
+
+func (UnlockerArgs) Kind() string { return UnlockerID }
+
+func (w *UnlockerWorker) Work(ctx context.Context, _ *river.Job[UnlockerArgs]) error {
+	stuckOTXs, err := w.getStuckOTXs(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(stuckOTXs) == 0 {
+		w.wc.logg.Debug("unlocker: no stuck transactions older than 5 minutes")
+		return nil
+	}
+
+	accounts := affectedAccounts(stuckOTXs)
+	w.wc.logg.Info("unlocker: processing affected accounts", "count", len(accounts))
+
+	for account := range accounts {
+		if err := w.processAccount(ctx, account); err != nil {
+			w.wc.logg.Error("unlocker: failed to process account", "account", account, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (w *UnlockerWorker) processAccount(ctx context.Context, account string) error {
+	var networkNonce uint64
+	if err := w.wc.chainProvider.Client.CallCtx(
+		ctx,
+		eth.Nonce(common.HexToAddress(account), nil).Returns(&networkNonce),
+	); err != nil {
+		return err
+	}
+	w.wc.logg.Info("unlocker: network nonce", "account", account, "nonce", networkNonce)
+
+	otxs, err := w.getOTXsFromNonce(ctx, account, networkNonce)
+	if err != nil {
+		return err
+	}
+
+	if len(otxs) == 0 {
+		return nil
+	}
+	w.wc.logg.Info("unlocker: resubmitting from nonce", "account", account, "count", len(otxs), "from_nonce", otxs[0].Nonce)
+
+	for _, otx := range otxs {
+		w.wc.logg.Info("unlocker: processing OTX",
+			"otx_id", otx.ID,
+			"nonce", otx.Nonce,
+			"status", otx.DispatchStatus,
+			"type", otx.OTXType,
+		)
+
+		if err := w.processOTX(ctx, otx); err != nil {
+			w.wc.logg.Error("unlocker: failed to process OTX, stopping account sequence",
+				"otx_id", otx.ID,
+				"nonce", otx.Nonce,
+				"error", err,
+			)
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func (w *UnlockerWorker) processOTX(ctx context.Context, otx *store.OTX) error {
+	rawTxBytes, err := hexutil.Decode(otx.RawTx)
+	if err != nil {
+		return err
+	}
+
+	if err := w.sendRawTx(ctx, rawTxBytes); err == nil {
+		w.wc.logg.Info("unlocker: resubmitted successfully", "otx_id", otx.ID, "nonce", otx.Nonce)
+		return w.setStatus(ctx, otx.ID, store.IN_NETWORK)
+	} else {
+		errType := unlockerClassifyRPCError(err)
+		w.wc.logg.Info("unlocker: resubmit error", "otx_id", otx.ID, "type", errType, "error", err)
+
+		switch errType {
+		case "nonce_low":
+			return w.checkReceipt(ctx, otx)
+
+		case "gas_price", "replacement_underpriced":
+			return w.resignAndResubmit(ctx, otx)
+
+		case "no_gas":
+			w.wc.logg.Warn("unlocker: account has no gas, stopping sequence", "otx_id", otx.ID)
+			return nil
+
+		default:
+			return err
+		}
+	}
+}
+
+func (w *UnlockerWorker) sendRawTx(ctx context.Context, rawTx []byte) error {
+	var txHash common.Hash
+	var callErrs w3.CallErrors
+
+	if err := w.wc.chainProvider.Client.CallCtx(ctx, eth.SendRawTx(rawTx).Returns(&txHash)); errors.As(err, &callErrs) {
+		if jsonErr, ok := callErrs[0].(rpc.Error); ok {
+			if classified := handleJSONRPCError(jsonErr.Error()); classified != nil {
+				return &DispatchError{Err: classified, OriginalErr: jsonErr}
+			}
+		}
+		return callErrs[0]
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (w *UnlockerWorker) checkReceipt(ctx context.Context, otx *store.OTX) error {
+	var receipt *types.Receipt
+	if err := w.wc.chainProvider.Client.CallCtx(
+		ctx,
+		eth.TxReceipt(common.HexToHash(otx.TxHash)).Returns(&receipt),
+	); err != nil {
+		return err
+	}
+
+	status := store.REVERTED
+	if receipt != nil && receipt.Status == 1 {
+		status = store.SUCCESS
+	}
+
+	return w.setStatus(ctx, otx.ID, status)
+}
+
+func (w *UnlockerWorker) resignAndResubmit(ctx context.Context, otx *store.OTX) error {
+	originalTxBytes, err := hexutil.Decode(otx.RawTx)
+	if err != nil {
+		return err
+	}
+
+	originalTx := new(types.Transaction)
+	if err := originalTx.UnmarshalBinary(originalTxBytes); err != nil {
+		return err
+	}
+
+	if originalTx.To() == nil {
+		return nil
+	}
+
+	gasSettings, err := w.wc.gasOracle.GetSettings()
+	if err != nil {
+		return err
+	}
+
+	newGasFeeCap := gasSettings.GasFeeCap
+	newGasTipCap := gasSettings.GasTipCap
+
+	if originalTx.GasFeeCap() != nil && newGasFeeCap.Cmp(originalTx.GasFeeCap()) <= 0 {
+		bump := new(big.Int).Mul(originalTx.GasFeeCap(), big.NewInt(115))
+		newGasFeeCap = bump.Div(bump, big.NewInt(100))
+	}
+	if originalTx.GasTipCap() != nil && newGasTipCap.Cmp(originalTx.GasTipCap()) <= 0 {
+		bump := new(big.Int).Mul(originalTx.GasTipCap(), big.NewInt(115))
+		newGasTipCap = bump.Div(bump, big.NewInt(100))
+	}
+
+	dbTx, err := w.wc.store.Pool().Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer dbTx.Rollback(ctx)
+
+	keypair, err := w.wc.store.LoadPrivateKey(ctx, dbTx, otx.SignerAccount)
+	if err != nil {
+		return err
+	}
+
+	privateKey, err := crypto.HexToECDSA(keypair.Private)
+	if err != nil {
+		return err
+	}
+
+	newTx, err := types.SignNewTx(privateKey, w.wc.chainProvider.Signer, &types.DynamicFeeTx{
+		Nonce:     originalTx.Nonce(),
+		To:        originalTx.To(),
+		Value:     originalTx.Value(),
+		Data:      originalTx.Data(),
+		Gas:       originalTx.Gas(),
+		GasFeeCap: newGasFeeCap,
+		GasTipCap: newGasTipCap,
+	})
+	if err != nil {
+		return err
+	}
+
+	newRawTxBytes, err := newTx.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	if err := w.sendRawTx(ctx, newRawTxBytes); err != nil {
+		return err
+	}
+
+	newRawTxHex := hexutil.Encode(newRawTxBytes)
+	newTxHash := newTx.Hash().Hex()
+
+	if _, err := dbTx.Exec(ctx,
+		`UPDATE otx SET raw_tx = $1, tx_hash = $2 WHERE id = $3`,
+		newRawTxHex, newTxHash, otx.ID,
+	); err != nil {
+		return err
+	}
+
+	if err := w.wc.store.UpdateDispatchTxStatus(ctx, dbTx, store.DispatchTx{
+		OTXID:  otx.ID,
+		Status: store.IN_NETWORK,
+	}); err != nil {
+		return err
+	}
+
+	w.wc.logg.Info("unlocker: re-signed and resubmitted", "otx_id", otx.ID, "new_tx_hash", newTxHash)
+	return dbTx.Commit(ctx)
+}
+
+func (w *UnlockerWorker) setStatus(ctx context.Context, otxID uint64, status string) error {
+	dbTx, err := w.wc.store.Pool().Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer dbTx.Rollback(ctx)
+
+	if err := w.wc.store.UpdateDispatchTxStatus(ctx, dbTx, store.DispatchTx{
+		OTXID:  otxID,
+		Status: status,
+	}); err != nil {
+		return err
+	}
+
+	return dbTx.Commit(ctx)
+}
+
+func (w *UnlockerWorker) getStuckOTXs(ctx context.Context) ([]*store.OTX, error) {
+	rows, err := w.wc.store.Pool().Query(ctx, `
+		SELECT otx.id, otx.tracking_id, otx.otx_type, keystore.public_key, otx.raw_tx, otx.tx_hash,
+		       otx.nonce, otx.replaced, otx.created_at, otx.updated_at, dispatch.status
+		FROM keystore
+		INNER JOIN otx ON keystore.id = otx.signer_account
+		INNER JOIN dispatch ON otx.id = dispatch.otx_id
+		WHERE dispatch.status NOT IN ('SUCCESS', 'REVERTED', 'PENDING', 'EXTERNAL_DISPATCH')
+		  AND otx.otx_type NOT IN ('GENERIC_SIGN', 'OTHER_MANUAL')
+		  AND dispatch.updated_at <= NOW() - INTERVAL '5 minutes'
+		ORDER BY otx.id ASC
+		LIMIT 100`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanOTXRows(rows)
+}
+
+func (w *UnlockerWorker) getOTXsFromNonce(ctx context.Context, account string, fromNonce uint64) ([]*store.OTX, error) {
+	rows, err := w.wc.store.Pool().Query(ctx, `
+		SELECT otx.id, otx.tracking_id, otx.otx_type, keystore.public_key, otx.raw_tx, otx.tx_hash,
+		       otx.nonce, otx.replaced, otx.created_at, otx.updated_at, dispatch.status
+		FROM keystore
+		INNER JOIN otx ON keystore.id = otx.signer_account
+		INNER JOIN dispatch ON otx.id = dispatch.otx_id
+		WHERE keystore.public_key = $1
+		  AND otx.nonce >= $2
+		ORDER BY otx.nonce ASC`, account, fromNonce)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanOTXRows(rows)
+}
+
+func scanOTXRows(rows interface{ Next() bool; Scan(...any) error; Err() error }) ([]*store.OTX, error) {
+	var otxs []*store.OTX
+	for rows.Next() {
+		o := &store.OTX{}
+		if err := rows.Scan(
+			&o.ID, &o.TrackingID, &o.OTXType, &o.SignerAccount,
+			&o.RawTx, &o.TxHash, &o.Nonce, &o.Replaced,
+			&o.CreatedAt, &o.UpdatedAt, &o.DispatchStatus,
+		); err != nil {
+			return nil, err
+		}
+		otxs = append(otxs, o)
+	}
+	return otxs, rows.Err()
+}
+
+func affectedAccounts(otxs []*store.OTX) map[string]struct{} {
+	accounts := make(map[string]struct{})
+	for _, otx := range otxs {
+		accounts[otx.SignerAccount] = struct{}{}
+	}
+	return accounts
+}
+
+func unlockerClassifyRPCError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "nonce too low"):
+		return "nonce_low"
+	case strings.Contains(msg, "replacement transaction underpriced"):
+		return "replacement_underpriced"
+	case strings.Contains(msg, "transaction underpriced"):
+		return "gas_price"
+	case strings.Contains(msg, "insufficient funds for gas"):
+		return "no_gas"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/worker/unlocker.go
+++ b/internal/worker/unlocker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -37,7 +38,7 @@ func (w *UnlockerWorker) Work(ctx context.Context, _ *river.Job[UnlockerArgs]) e
 	}
 
 	if len(stuckOTXs) == 0 {
-		w.wc.logg.Debug("unlocker: no stuck transactions older than 5 minutes")
+		w.wc.logg.Debug("unlocker: no stuck transactions older than configured threshold", "threshold", unlockerInterval)
 		return nil
 	}
 
@@ -136,7 +137,7 @@ func (w *UnlockerWorker) sendRawTx(ctx context.Context, rawTx []byte) error {
 		}
 		return callErrs[0]
 	} else if err != nil {
-		return err
+		return handleNetworkError(err)
 	}
 
 	return nil
@@ -152,7 +153,9 @@ func (w *UnlockerWorker) checkReceipt(ctx context.Context, otx *store.OTX) error
 	}
 
 	status := store.REVERTED
-	if receipt != nil && receipt.Status == 1 {
+	if receipt == nil {
+		return nil
+	} else if receipt.Status == 1 {
 		status = store.SUCCESS
 	}
 
@@ -172,6 +175,10 @@ func (w *UnlockerWorker) resignAndResubmit(ctx context.Context, otx *store.OTX) 
 
 	if originalTx.To() == nil {
 		return nil
+	}
+
+	if originalTx.Type() != types.DynamicFeeTxType {
+		return errors.New("cannot re-sign non-dynamic-fee transaction")
 	}
 
 	gasSettings, err := w.wc.gasOracle.GetSettings()
@@ -268,6 +275,7 @@ func (w *UnlockerWorker) setStatus(ctx context.Context, otxID uint64, status str
 }
 
 func (w *UnlockerWorker) getStuckOTXs(ctx context.Context) ([]*store.OTX, error) {
+	cutoff := time.Now().Add(-unlockerInterval)
 	rows, err := w.wc.store.Pool().Query(ctx, `
 		SELECT otx.id, otx.tracking_id, otx.otx_type, keystore.public_key, otx.raw_tx, otx.tx_hash,
 		       otx.nonce, otx.replaced, otx.created_at, otx.updated_at, dispatch.status
@@ -276,9 +284,9 @@ func (w *UnlockerWorker) getStuckOTXs(ctx context.Context) ([]*store.OTX, error)
 		INNER JOIN dispatch ON otx.id = dispatch.otx_id
 		WHERE dispatch.status NOT IN ('SUCCESS', 'REVERTED', 'PENDING', 'EXTERNAL_DISPATCH')
 		  AND otx.otx_type NOT IN ('GENERIC_SIGN', 'OTHER_MANUAL')
-		  AND dispatch.updated_at <= NOW() - INTERVAL '5 minutes'
+		  AND dispatch.updated_at <= $1
 		ORDER BY otx.id ASC
-		LIMIT 100`)
+		LIMIT 100`, cutoff)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -97,7 +97,7 @@ func New(o WorkerOpts) (*WorkerContainer, error) {
 			},
 		},
 		Workers:      workers,
-		PeriodicJobs: setupHealthCheck(),
+		PeriodicJobs: setupPeriodicJobs(),
 		Logger:       o.Logg,
 	})
 	if err != nil {
@@ -181,7 +181,7 @@ func setupWorkers(wc *WorkerContainer) (*river.Workers, error) {
 	return workers, nil
 }
 
-func setupHealthCheck() []*river.PeriodicJob {
+func setupPeriodicJobs() []*river.PeriodicJob {
 	return []*river.PeriodicJob{
 		river.NewPeriodicJob(
 			river.PeriodicInterval(healthCheckInterval),

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -53,6 +53,7 @@ type (
 const (
 	migrationTimeout    = 15 * time.Second
 	healthCheckInterval = 2 * time.Minute
+	unlockerInterval    = 5 * time.Minute
 )
 
 func New(o WorkerOpts) (*WorkerContainer, error) {
@@ -173,6 +174,10 @@ func setupWorkers(wc *WorkerContainer) (*river.Workers, error) {
 		return nil, err
 	}
 
+	if err := river.AddWorkerSafely(workers, &UnlockerWorker{wc: wc}); err != nil {
+		return nil, err
+	}
+
 	return workers, nil
 }
 
@@ -182,6 +187,15 @@ func setupHealthCheck() []*river.PeriodicJob {
 			river.PeriodicInterval(healthCheckInterval),
 			func() (river.JobArgs, *river.InsertOpts) {
 				return DispatchHealthCheckArgs{}, nil
+			},
+			&river.PeriodicJobOpts{
+				RunOnStart: true,
+			},
+		),
+		river.NewPeriodicJob(
+			river.PeriodicInterval(unlockerInterval),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return UnlockerArgs{}, nil
 			},
 			&river.PeriodicJobOpts{
 				RunOnStart: true,


### PR DESCRIPTION
Fixes several correctness and consistency issues in the unlocker worker identified during code review.

## Changes

- **`checkReceipt`**: return `nil` (no status change) when receipt is nil — tx may still be pending or replaced; only set `SUCCESS`/`REVERTED` on a confirmed receipt
- **`resignAndResubmit`**: guard against non-EIP-1559 transactions with an explicit type check before re-signing
  ```go
  if originalTx.Type() != types.DynamicFeeTxType {
      return errors.New("cannot re-sign non-dynamic-fee transaction")
  }
  ```
- **`sendRawTx`**: wrap non-JSON-RPC errors via `handleNetworkError` for consistency with the dispatch path
- **`getStuckOTXs`**: replace hardcoded `INTERVAL '5 minutes'` in SQL with a parameterized cutoff timestamp derived from the `unlockerInterval` constant, keeping scheduling and selection criteria in sync
- **Log message**: reference `unlockerInterval` in the "no stuck transactions" debug log instead of a hardcoded string
- **`setupHealthCheck` → `setupPeriodicJobs`**: rename to reflect that the function registers all periodic jobs, not just the health check